### PR TITLE
docs(readme): fix error export

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,7 @@ import Shared from '../model/shared'
 
 const stores = { Home, Shared }
 
-export default Model(stores)
-// the same as export const { getInitialState, useStore, getState, getActions, subscribe, unsubscribe } =
+export const { getInitialState, useStore, getState, getActions, subscribe, unsubscribe } = Model(stores)
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-model",
-  "version": "2.6.0-alpha.0",
+  "version": "2.6.0",
   "description": "The State management library for React",
   "main": "./dist/react-model.js",
   "umd:main": "./dist/react-model.umd.js",


### PR DESCRIPTION
export default Model(stores) will raise error.

![image](https://user-images.githubusercontent.com/21001457/55052312-6a93da80-5093-11e9-9257-0e3461fc6eb2.png)

We don't know what returns from Model(...)

You will need to write 🤔

```typescript
import Model from 'models/index'
const { useStore } = Model
```

So I revert the changes.
